### PR TITLE
Test files namespace changes

### DIFF
--- a/NetFlow-Iterative_ranking/description-wsDDv2.xml
+++ b/NetFlow-Iterative_ranking/description-wsDDv2.xml
@@ -5,7 +5,7 @@
     <description>Module for calculation flows of Net Flow Score in iterative way using chosen function and direction in parameters. Basing on them, there are designated positions in a ranking for each alternative.</description>
     <contact><![CDATA[Magdalena Dziecielska <magdalenadziecielska6@gmail.com>]]></contact>
     <url>https://github.com/MagdalenaDziecielska/PrometheeDiviz</url>
-    <reference>M. Kadziński and M. Michalski, 2016. Scoring procedures for multiple criteria decision aiding with robust and stochastic ordinal regression. Computers & Operations Research 71, 54–70.</reference>
+    <reference>M. Kadziński and M. Michalski, 2016. Scoring procedures for multiple criteria decision aiding with robust and stochastic ordinal regression. Computers &amp; Operations Research 71, 54–70.</reference>
   </documentation>
   <parameters>
 

--- a/NetFlow-Iterative_ranking/description-wsDDv3.xml
+++ b/NetFlow-Iterative_ranking/description-wsDDv3.xml
@@ -5,7 +5,7 @@
     <description>Module for calculation flows of Net Flow Score in iterative way using chosen function and direction in parameters. Basing on them, there are designated positions in a ranking for each alternative.</description>
     <contact><![CDATA[Magdalena Dziecielska <magdalenadziecielska6@gmail.com>]]></contact>
     <url>https://github.com/MagdalenaDziecielska/PrometheeDiviz</url>
-    <reference>M. Kadziński and M. Michalski, 2016. Scoring procedures for multiple criteria decision aiding with robust and stochastic ordinal regression. Computers & Operations Research 71, 54–70.</reference>
+    <reference>M. Kadziński and M. Michalski, 2016. Scoring procedures for multiple criteria decision aiding with robust and stochastic ordinal regression. Computers &amp; Operations Research 71, 54–70.</reference>
   </documentation>
   <parameters>
 

--- a/NetFlow-Iterative_ranking/tests/out1.v2/messages.xml
+++ b/NetFlow-Iterative_ranking/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/NetFlow-Iterative_ranking/tests/out1.v2/ranking.xml
+++ b/NetFlow-Iterative_ranking/tests/out1.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>B</alternativeID>

--- a/NetFlow-Iterative_ranking/tests/out2.v2/messages.xml
+++ b/NetFlow-Iterative_ranking/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/NetFlow-Iterative_ranking/tests/out2.v2/ranking.xml
+++ b/NetFlow-Iterative_ranking/tests/out2.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>B</alternativeID>

--- a/NetFlow-Iterative_ranking/tests/out3.v2/messages.xml
+++ b/NetFlow-Iterative_ranking/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/NetFlow-Iterative_ranking/tests/out3.v2/ranking.xml
+++ b/NetFlow-Iterative_ranking/tests/out3.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/NetFlow_scores/tests/out1.v2/flows.xml
+++ b/NetFlow_scores/tests/out1.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/NetFlow_scores/tests/out1.v2/messages.xml
+++ b/NetFlow_scores/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/NetFlow_scores/tests/out2.v2/flows.xml
+++ b/NetFlow_scores/tests/out2.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/NetFlow_scores/tests/out2.v2/messages.xml
+++ b/NetFlow_scores/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/NetFlow_scores/tests/out3.v2/flows.xml
+++ b/NetFlow_scores/tests/out3.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/NetFlow_scores/tests/out3.v2/messages.xml
+++ b/NetFlow_scores/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II-GDSS_flows/tests/in1.v2/method_parameters.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/in1.v2/method_parameters.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
         <parameter id="decisionMaker1">
             <value>

--- a/PROMETHEE-II-GDSS_flows/tests/in2.v2/method_parameters.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/in2.v2/method_parameters.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
         <parameter id="decisionMaker1">
             <value>

--- a/PROMETHEE-II-GDSS_flows/tests/in3.v2/method_parameters.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/in3.v2/method_parameters.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
         <parameter id="decisionMaker1">
             <value>

--- a/PROMETHEE-II-GDSS_flows/tests/out1.v2/aggregated_flows.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out1.v2/aggregated_flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons>
         <pairs>
             <pair>

--- a/PROMETHEE-II-GDSS_flows/tests/out1.v2/messages.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II-GDSS_flows/tests/out1.v2/ranking.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out1.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-II-GDSS_flows/tests/out2.v2/aggregated_flows.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out2.v2/aggregated_flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons>
         <pairs>
             <pair>

--- a/PROMETHEE-II-GDSS_flows/tests/out2.v2/messages.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II-GDSS_flows/tests/out2.v2/ranking.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out2.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-II-GDSS_flows/tests/out3.v2/aggregated_flows.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out3.v2/aggregated_flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons>
         <pairs>
             <pair>

--- a/PROMETHEE-II-GDSS_flows/tests/out3.v2/messages.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II-GDSS_flows/tests/out3.v2/ranking.xml
+++ b/PROMETHEE-II-GDSS_flows/tests/out3.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-III_flows/tests/in.portfolio.v2/preferences.xml
+++ b/PROMETHEE-III_flows/tests/in.portfolio.v2/preferences.xml
@@ -1,4 +1,4 @@
-<ns0:XMCDA xmlns:ns0="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns0:XMCDA xmlns:ns0="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons>
         <pairs>
             <pair>

--- a/PROMETHEE-III_flows/tests/in1.v2/preferences.xml
+++ b/PROMETHEE-III_flows/tests/in1.v2/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
   <alternativesComparisons>
     <pairs>
       <pair>

--- a/PROMETHEE-III_flows/tests/out.portfolio.v2/intervals.xml
+++ b/PROMETHEE-III_flows/tests/out.portfolio.v2/intervals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a11</alternativeID>

--- a/PROMETHEE-III_flows/tests/out.portfolio.v2/messages.xml
+++ b/PROMETHEE-III_flows/tests/out.portfolio.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-III_flows/tests/out.portfolio.v2/ranking.xml
+++ b/PROMETHEE-III_flows/tests/out.portfolio.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-III_flows/tests/out1.v2/intervals.xml
+++ b/PROMETHEE-III_flows/tests/out1.v2/intervals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a02</alternativeID>

--- a/PROMETHEE-III_flows/tests/out1.v2/messages.xml
+++ b/PROMETHEE-III_flows/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-III_flows/tests/out1.v2/ranking.xml
+++ b/PROMETHEE-III_flows/tests/out1.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-III_flows/tests/out2.v2/intervals.xml
+++ b/PROMETHEE-III_flows/tests/out2.v2/intervals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-III_flows/tests/out2.v2/messages.xml
+++ b/PROMETHEE-III_flows/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-III_flows/tests/out2.v2/ranking.xml
+++ b/PROMETHEE-III_flows/tests/out2.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-III_flows/tests/out3.v2/intervals.xml
+++ b/PROMETHEE-III_flows/tests/out3.v2/intervals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-III_flows/tests/out3.v2/messages.xml
+++ b/PROMETHEE-III_flows/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-III_flows/tests/out3.v2/ranking.xml
+++ b/PROMETHEE-III_flows/tests/out3.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-II_flows/tests/in1.v2/categories_profiles.xml
+++ b/PROMETHEE-II_flows/tests/in1.v2/categories_profiles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmcda:XMCDA xmlns:xmcda='http://www.decision-deck.org/2016/XMCDA-2.2.2'
+<xmcda:XMCDA xmlns:xmcda='http://www.decision-deck.org/2017/XMCDA-2.2.2'
 			 xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-			 xsi:schemaLocation='http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd'>
+			 xsi:schemaLocation='http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd'>
 	<projectReference>
 		<title>SixRealCars - Categories profiles</title>
 		<comment>Only the profiles and categories association, from the "SixRealCars" data set.</comment>

--- a/PROMETHEE-II_flows/tests/out1.v2/flows.xml
+++ b/PROMETHEE-II_flows/tests/out1.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-II_flows/tests/out1.v2/messages.xml
+++ b/PROMETHEE-II_flows/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II_flows/tests/out2.v2/flows.xml
+++ b/PROMETHEE-II_flows/tests/out2.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-II_flows/tests/out2.v2/messages.xml
+++ b/PROMETHEE-II_flows/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-II_flows/tests/out3.v2/flows.xml
+++ b/PROMETHEE-II_flows/tests/out3.v2/flows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>A</alternativeID>

--- a/PROMETHEE-II_flows/tests/out3.v2/messages.xml
+++ b/PROMETHEE-II_flows/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-I_ranking/tests/out1.v2/messages.xml
+++ b/PROMETHEE-I_ranking/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-I_ranking/tests/out1.v2/ranking.xml
+++ b/PROMETHEE-I_ranking/tests/out1.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-I_ranking/tests/out2.v2/messages.xml
+++ b/PROMETHEE-I_ranking/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-I_ranking/tests/out2.v2/ranking.xml
+++ b/PROMETHEE-I_ranking/tests/out2.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/PROMETHEE-I_ranking/tests/out3.v2/messages.xml
+++ b/PROMETHEE-I_ranking/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/PROMETHEE-I_ranking/tests/out3.v2/ranking.xml
+++ b/PROMETHEE-I_ranking/tests/out3.v2/ranking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesComparisons mcdaConcept="atLeastAsGoodAs">
         <pairs>
             <pair>

--- a/groupClassAcceptabilities/tests/in1.v2/assignments_1.xml
+++ b/groupClassAcceptabilities/tests/in1.v2/assignments_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in1.v2/assignments_2.xml
+++ b/groupClassAcceptabilities/tests/in1.v2/assignments_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in1.v2/categories.xml
+++ b/groupClassAcceptabilities/tests/in1.v2/categories.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categories id="categories1" name="categories1 name" mcdaConcept="categories1 mcdaConcept">
         <category id="C1">
             <active>true</active>

--- a/groupClassAcceptabilities/tests/in1.v2/categories_values.xml
+++ b/groupClassAcceptabilities/tests/in1.v2/categories_values.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categoriesValues>
         <categoryValue>
             <categoryID>C1</categoryID>

--- a/groupClassAcceptabilities/tests/in2.v2/assignments_1.xml
+++ b/groupClassAcceptabilities/tests/in2.v2/assignments_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in2.v2/assignments_2.xml
+++ b/groupClassAcceptabilities/tests/in2.v2/assignments_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in2.v2/categories.xml
+++ b/groupClassAcceptabilities/tests/in2.v2/categories.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categories id="categories1" name="categories1 name" mcdaConcept="categories1 mcdaConcept">
         <category id="C1">
             <active>true</active>

--- a/groupClassAcceptabilities/tests/in2.v2/categories_values.xml
+++ b/groupClassAcceptabilities/tests/in2.v2/categories_values.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categoriesValues>
         <categoryValue>
             <categoryID>C1</categoryID>

--- a/groupClassAcceptabilities/tests/in3.v2/assignments_1.xml
+++ b/groupClassAcceptabilities/tests/in3.v2/assignments_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in3.v2/assignments_2.xml
+++ b/groupClassAcceptabilities/tests/in3.v2/assignments_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesAffectations>
         <alternativeAffectation>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/in3.v2/categories.xml
+++ b/groupClassAcceptabilities/tests/in3.v2/categories.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categories id="categories1" name="categories1 name" mcdaConcept="categories1 mcdaConcept">
         <category id="C1">
             <active>true</active>

--- a/groupClassAcceptabilities/tests/in3.v2/categories_values.xml
+++ b/groupClassAcceptabilities/tests/in3.v2/categories_values.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmcda:XMCDA
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xmcda="http://www.decision-deck.org/2016/XMCDA-2.2.2"
-        xsi:schemaLocation="http://www.decision-deck.org/2016/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
+        xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
+        xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <categoriesValues>
         <categoryValue>
             <categoryID>C1</categoryID>

--- a/groupClassAcceptabilities/tests/out1.v2/alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out1.v2/alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/out1.v2/messages.xml
+++ b/groupClassAcceptabilities/tests/out1.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/groupClassAcceptabilities/tests/out1.v2/unimodal_alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out1.v2/unimodal_alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/out2.v2/alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out2.v2/alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/out2.v2/messages.xml
+++ b/groupClassAcceptabilities/tests/out2.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/groupClassAcceptabilities/tests/out2.v2/unimodal_alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out2.v2/unimodal_alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/out3.v2/alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out3.v2/alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>

--- a/groupClassAcceptabilities/tests/out3.v2/messages.xml
+++ b/groupClassAcceptabilities/tests/out3.v2/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <methodMessages>
         <logMessage>
             <text>Success</text>

--- a/groupClassAcceptabilities/tests/out3.v2/unimodal_alternatives_support.xml
+++ b/groupClassAcceptabilities/tests/out3.v2/unimodal_alternatives_support.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2016/XMCDA-2.2.2">
+<ns2:XMCDA xmlns:ns2="http://www.decision-deck.org/2017/XMCDA-2.2.2">
     <alternativesValues>
         <alternativeValue>
             <alternativeID>a1</alternativeID>


### PR DESCRIPTION
Hi Magdalena,

This PR which mainly changes the XMCDA v2.2.2 namespace from:
  `http://www.decision-deck.org/2016/XMCDA-2.2.2`
to:
  `http://www.decision-deck.org/2017/XMCDA-2.2.2`.
Best regards,
__ Sébastien.